### PR TITLE
Fix segfault by using lea instruction

### DIFF
--- a/src/backend/nasm.c
+++ b/src/backend/nasm.c
@@ -232,6 +232,15 @@ static void emit_instr_label(struct state *state, const struct x86_instr *instr)
     fprintf(state->f, "%s:\n", dst);
 }
 
+static void emit_instr_lea(struct state *state, const struct x86_instr *instr) {
+    char dst[OPERAND_BUFFER_SIZE];
+    char src[OPERAND_BUFFER_SIZE];
+    format_operand(dst, sizeof(dst), instr->dst);
+    format_operand(src, sizeof(src), instr->src);
+    
+    fprintf(state->f, INDENT "lea %s, %s\n", dst, src);
+}
+
 static void emit_instr_mov(struct state *state, const struct x86_instr *instr) {
     char dst[OPERAND_BUFFER_SIZE];
     char src[OPERAND_BUFFER_SIZE];
@@ -320,6 +329,8 @@ static void emit_code(struct state *state, const struct x86_instr *instr) {
         case X86_INSTR_LABEL:
             emit_instr_label(state, instr);
             break;
+        case X86_INSTR_LEA:
+            emit_instr_lea(state, instr);
         case X86_INSTR_MOV:
             emit_instr_mov(state, instr);
             break;

--- a/src/backend/nasm.c
+++ b/src/backend/nasm.c
@@ -338,6 +338,7 @@ static void emit_code(struct state *state, const struct x86_instr *instr) {
             break;
         case X86_INSTR_LEA:
             emit_instr_lea(state, instr);
+            break;
         case X86_INSTR_MOV:
             emit_instr_mov(state, instr);
             break;

--- a/src/backend/nasm.c
+++ b/src/backend/nasm.c
@@ -38,7 +38,7 @@
 #include "x86/isa.h"
 
 #define INDENT "    "
-#define OPERAND_BUFFER_SIZE 32
+#define OPERAND_BUFFER_SIZE 64
 
 struct state {
     FILE *f;
@@ -76,6 +76,10 @@ static size_t format_operand_mem8_reg(char *buf, size_t bufsize, const struct x8
 
 static size_t format_operand_mem64_extern(char *buf, size_t bufsize, const struct x86_operand *operand) {
     return snprintf(buf, bufsize, "qword [%s]", extern_symbol_names[operand->n]);
+}
+
+static size_t format_operand_mem64_label(char *buf, size_t bufsize, const struct x86_operand *operand) {
+    return snprintf(buf, bufsize, "qword [.l%08d]", (int)operand->n);
 }
 
 static size_t format_operand_mem64_local(char *buf, size_t bufsize, const struct x86_operand *operand) {
@@ -122,6 +126,9 @@ static void format_operand(char *buf, size_t bufsize, const struct x86_operand *
         break;
     case X86_OPERAND_MEM64_EXTERN:
         retsize = format_operand_mem64_extern(buf, bufsize, operand);
+        break;
+    case X86_OPERAND_MEM64_LABEL:
+        retsize = format_operand_mem64_label(buf, bufsize, operand);
         break;
     case X86_OPERAND_MEM64_LOCAL:
         retsize = format_operand_mem64_local(buf, bufsize, operand);

--- a/src/backend/x86/codegen.c
+++ b/src/backend/x86/codegen.c
@@ -375,9 +375,9 @@ static struct x86_instr *generate_start(void) {
     x86_builder_append_instr(&builder, x86_instr_new_push(
         x86_operand_new_reg64(X86_REG_RSP)
     ));
-    x86_builder_append_instr(&builder, x86_instr_new_mov(
+    x86_builder_append_instr(&builder, x86_instr_new_lea(
         x86_operand_new_reg64(REG64ARG4),
-        x86_operand_new_label(label_return)
+        x86_operand_new_mem64_label(label_return)
     ));
     x86_builder_append_instr(&builder, x86_instr_new_mov(
         x86_operand_new_reg64(REG64ARG5),

--- a/src/backend/x86/codegen.c
+++ b/src/backend/x86/codegen.c
@@ -383,9 +383,9 @@ static struct x86_instr *generate_start(void) {
         x86_operand_new_reg64(REG64ARG5),
         x86_operand_new_reg64(REG64ARG4)
     ));
-    x86_builder_append_instr(&builder, x86_instr_new_mov(
+    x86_builder_append_instr(&builder, x86_instr_new_lea(
         x86_operand_new_reg64(REG64ARG1),
-        x86_operand_new_local(LOCAL_MAIN)
+        x86_operand_new_mem64_local(LOCAL_MAIN)
     ));
     x86_builder_append_instr(&builder, x86_instr_new_call(
         x86_operand_new_extern(EXTERN_LIBC_START_MAIN)
@@ -412,9 +412,9 @@ static struct x86_instr *generate_fail_too_far(local_symbol message) {
         x86_operand_new_reg64(REG64ARG1),
         x86_operand_new_mem64_extern(EXTERN_STDERR)
     ));
-    x86_builder_append_instr(&builder, x86_instr_new_mov(
+    x86_builder_append_instr(&builder, x86_instr_new_lea(
         x86_operand_new_reg64(REG64ARG2),
-        x86_operand_new_local(message)
+        x86_operand_new_mem64_local(message)
     ));
     x86_builder_append_instr(&builder, x86_instr_new_call(
         x86_operand_new_extern(EXTERN_FPRINTF)
@@ -467,9 +467,9 @@ static struct x86_instr *generate_check_input(void) {
         x86_operand_new_label(label_eoi)
     ));
     
-    x86_builder_append_instr(&builder, x86_instr_new_mov(
+    x86_builder_append_instr(&builder, x86_instr_new_lea(
         x86_operand_new_reg64(REG64ARG1),
-        x86_operand_new_local(LOCAL_MSG_FERR)
+        x86_operand_new_mem64_local(LOCAL_MSG_FERR)
     ));
     x86_builder_append_instr(&builder, x86_instr_new_call(
         x86_operand_new_extern(EXTERN_PERROR)
@@ -484,9 +484,9 @@ static struct x86_instr *generate_check_input(void) {
         x86_operand_new_reg64(REG64ARG1),
         x86_operand_new_mem64_extern(EXTERN_STDERR)
     ));
-    x86_builder_append_instr(&builder, x86_instr_new_mov(
+    x86_builder_append_instr(&builder, x86_instr_new_lea(
         x86_operand_new_reg64(REG64ARG2),
-        x86_operand_new_local(LOCAL_MSG_EOI)
+        x86_operand_new_mem64_local(LOCAL_MSG_EOI)
     ));
     x86_builder_append_instr(&builder, x86_instr_new_call(
         x86_operand_new_extern(EXTERN_FPRINTF)

--- a/src/backend/x86/isa.c
+++ b/src/backend/x86/isa.c
@@ -402,6 +402,18 @@ struct x86_instr *x86_instr_new_label(int n) {
     return instr;
 }
 
+struct x86_instr *x86_instr_new_lea(struct x86_operand *dst, struct x86_operand *src) {
+        const struct two_operand_types supported[] = {
+        {X86_OPERAND_REG64, X86_OPERAND_MEM64_LOCAL},
+    };
+    check_both_operand_types(dst, src, supported, sizeof(supported), "lea");
+    
+    struct x86_instr *instr = x86_instr_new(X86_INSTR_LEA);
+    instr->dst = dst;
+    instr->src = src;
+    return instr;
+}
+
 struct x86_instr *x86_instr_new_mov(struct x86_operand *dst, struct x86_operand *src) {
     const struct two_operand_types supported[] = {
         {X86_OPERAND_MEM8_REG, X86_OPERAND_REG8},
@@ -409,8 +421,8 @@ struct x86_instr *x86_instr_new_mov(struct x86_operand *dst, struct x86_operand 
         {X86_OPERAND_REG8, X86_OPERAND_MEM8_REG},
         {X86_OPERAND_REG32, X86_OPERAND_IMM32},
         {X86_OPERAND_REG32, X86_OPERAND_REG32},
+        /* TODO convert this to lea too*/
         {X86_OPERAND_REG64, X86_OPERAND_LABEL},
-        {X86_OPERAND_REG64, X86_OPERAND_LOCAL},
         {X86_OPERAND_REG64, X86_OPERAND_MEM64_EXTERN},
         {X86_OPERAND_REG64, X86_OPERAND_MEM64_LOCAL},
         {X86_OPERAND_REG64, X86_OPERAND_REG64},

--- a/src/backend/x86/isa.c
+++ b/src/backend/x86/isa.c
@@ -149,6 +149,12 @@ struct x86_operand *x86_operand_new_mem64_extern(extern_symbol symbol) {
     return operand;
 }
 
+struct x86_operand *x86_operand_new_mem64_label(int n) {
+    struct x86_operand *operand = oper_new(X86_OPERAND_MEM64_LABEL);
+    operand->n = n;
+    return operand;
+}
+
 struct x86_operand *x86_operand_new_mem64_local(local_symbol symbol) {
     struct x86_operand *operand = oper_new(X86_OPERAND_MEM64_LOCAL);
     operand->n = symbol;
@@ -186,43 +192,9 @@ void x86_operand_free(struct x86_operand *operand) {
 bool x86_operand_is_64bit(const struct x86_operand *oper) {
     switch(oper->type) {
     case X86_OPERAND_MEM64_EXTERN:
+    case X86_OPERAND_MEM64_LABEL:
     case X86_OPERAND_MEM64_LOCAL:
     case X86_OPERAND_REG64:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool x86_operand_is_register(const struct x86_operand *oper) {
-    switch(oper->type) {
-    case X86_OPERAND_REG8:
-    case X86_OPERAND_REG32:
-    case X86_OPERAND_REG64:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool x86_operand_is_memory(const struct x86_operand *oper) {
-    switch(oper->type) {
-    case X86_OPERAND_MEM8_REG:
-    case X86_OPERAND_MEM64_EXTERN:
-    case X86_OPERAND_MEM64_LOCAL:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool x86_operand_is_immediate(const struct x86_operand *oper) {
-    switch(oper->type) {
-    case X86_OPERAND_EXTERN:
-    case X86_OPERAND_IMM8:
-    case X86_OPERAND_IMM32:
-    case X86_OPERAND_LABEL:
-    case X86_OPERAND_LOCAL:
         return true;
     default:
         return false;
@@ -404,6 +376,7 @@ struct x86_instr *x86_instr_new_label(int n) {
 
 struct x86_instr *x86_instr_new_lea(struct x86_operand *dst, struct x86_operand *src) {
         const struct two_operand_types supported[] = {
+        {X86_OPERAND_REG64, X86_OPERAND_MEM64_LABEL},
         {X86_OPERAND_REG64, X86_OPERAND_MEM64_LOCAL},
     };
     check_both_operand_types(dst, src, supported, sizeof(supported), "lea");
@@ -421,8 +394,6 @@ struct x86_instr *x86_instr_new_mov(struct x86_operand *dst, struct x86_operand 
         {X86_OPERAND_REG8, X86_OPERAND_MEM8_REG},
         {X86_OPERAND_REG32, X86_OPERAND_IMM32},
         {X86_OPERAND_REG32, X86_OPERAND_REG32},
-        /* TODO convert this to lea too*/
-        {X86_OPERAND_REG64, X86_OPERAND_LABEL},
         {X86_OPERAND_REG64, X86_OPERAND_MEM64_EXTERN},
         {X86_OPERAND_REG64, X86_OPERAND_MEM64_LOCAL},
         {X86_OPERAND_REG64, X86_OPERAND_REG64},

--- a/src/backend/x86/isa.h
+++ b/src/backend/x86/isa.h
@@ -110,6 +110,7 @@ typedef enum {
     X86_INSTR_JNZ,
     X86_INSTR_JZ,
     X86_INSTR_LABEL,
+    X86_INSTR_LEA,
     X86_INSTR_MOV,
     X86_INSTR_MOVZX,
     X86_INSTR_OR,
@@ -205,6 +206,8 @@ struct x86_instr *x86_instr_new_jnz(struct x86_operand *target);
 struct x86_instr *x86_instr_new_jz(struct x86_operand *target);
 
 struct x86_instr *x86_instr_new_label(int n);
+
+struct x86_instr *x86_instr_new_lea(struct x86_operand *dst, struct x86_operand *src);
 
 struct x86_instr *x86_instr_new_mov(struct x86_operand *dst, struct x86_operand *src);
 

--- a/src/backend/x86/isa.h
+++ b/src/backend/x86/isa.h
@@ -128,6 +128,7 @@ typedef enum {
     X86_OPERAND_LOCAL,
     X86_OPERAND_MEM8_REG,
     X86_OPERAND_MEM64_EXTERN,
+    X86_OPERAND_MEM64_LABEL,
     X86_OPERAND_MEM64_LOCAL,
     X86_OPERAND_MEM64_REL,
     X86_OPERAND_REG8,
@@ -157,6 +158,8 @@ struct x86_operand *x86_operand_new_mem8_reg(x86_reg64 r1, x86_reg64 r2, int n);
 
 struct x86_operand *x86_operand_new_mem64_extern(extern_symbol symbol);
 
+struct x86_operand *x86_operand_new_mem64_label(int n);
+
 struct x86_operand *x86_operand_new_mem64_local(local_symbol symbol);
 
 struct x86_operand *x86_operand_new_mem64_rel(uint64_t address);
@@ -170,12 +173,6 @@ struct x86_operand *x86_operand_new_reg64(x86_reg64 r);
 void x86_operand_free(struct x86_operand *oper);
 
 bool x86_operand_is_64bit(const struct x86_operand *oper);
-
-bool x86_operand_is_register(const struct x86_operand *oper);
-
-bool x86_operand_is_memory(const struct x86_operand *oper);
-
-bool x86_operand_is_immediate(const struct x86_operand *oper);
 
 struct x86_instr {
     x86_instr_op op;


### PR DESCRIPTION
The JIT requires the code generated by the code generator to be position independent. Currently, this is not the case when we attempt to move the address of a local function or a label into a register. We change that here by using the `lea` instruction instead of the `mov` instruction. This allows us to use the RIP-relative form of the `lea` instruction.

This fixes an issue where, when certain errors such as a bound check failure happen, the program segfaults instead of printing the expected error message and exiting cleanly.
